### PR TITLE
Fix for maps with null keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.4
+  * Fix to handle null keys in maps.
+
 ## 0.10.3
   * Clean up setup for serialization. Adds `addRules`,
     `defaultFormat`, and a named `format` parameter to

--- a/lib/src/serialization_rule.dart
+++ b/lib/src/serialization_rule.dart
@@ -249,14 +249,15 @@ class MapRule extends SerializationRule {
   }
 
   void inflateNonEssentialFromList(List state, Map newMap, Reader r) {
+    bool isNextOneKey = true;
     var key;
     for (var each in state) {
-      if (key == null) {
+      if (isNextOneKey == true) {
         key = each;
       } else {
         newMap[r.inflateReference(key)] = r.inflateReference(each);
-        key = null;
       }
+      isNextOneKey = !isNextOneKey;
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: serialization
-version: 0.10.3
+version: 0.10.4-dev
 author: Alan Knight <alanknight@google.com>
 description: Provide a serialization facility for Dart objects.
 homepage: https://github.com/google/serialization.dart

--- a/test/transformer/test_models.dart
+++ b/test/transformer/test_models.dart
@@ -33,3 +33,8 @@ class ThingWithConstructor {
   set settable(x) => _settable = x;
   verifyPrivate(x) => _priv == x;
 }
+
+// to test the case in which a map has a null key
+class ThingWithMap {
+  Map<int, int> m = {null: 1, 10: 11};
+}

--- a/test/transformer/test_models_for_maps.dart
+++ b/test/transformer/test_models_for_maps.dart
@@ -41,3 +41,9 @@ class ThingWithDate {
   String s;
   DateTime d;
 }
+
+// to test the case in which a map has a null key
+class ThingWithMap {
+  Map<int, int> m = {null: 1, 10: 11};
+}
+

--- a/test/transformer/transformer_test_core.dart
+++ b/test/transformer/transformer_test_core.dart
@@ -18,6 +18,8 @@ var thing2 = new OtherThing.constructor()
 var constructor =
     new ThingWithConstructor("a", "b", "whatever")..settable = "c"..other = "d";
 
+var thingWithMap = new ThingWithMap();
+
 Format format = const SimpleJsonFormat(storeRoundTripInfo: true);
 
 main() {
@@ -70,5 +72,16 @@ main() {
     expect(read.other, "d");
     expect(read.settable, "c");
     expect(read.verifyPrivate("a"), isTrue);
+  });
+  
+  test("Map with a null key", () {
+    var written = serialization1.write(thingWithMap);
+    var read = serialization2.read(written);
+    expect(read is ThingWithMap, isTrue);
+    expect(read.m is Map, isTrue);
+    expect(read.m.length, 2);
+    expect(read.m[null], 1);
+    expect(read.m[10], 11);
+    expect(read.m, {null: 1, 10: 11});
   });
 }


### PR DESCRIPTION
Right now this code assumes that maps would not have null keys. However, dart allows maps to have null keys. Right now, the value corresponding to the null key is used as the next key, and everything in the list is shifted left by one. More explicitly enforcing odd and even entries with a bool avoids this bug.